### PR TITLE
Updating Makefile to checkout tmux-1.9a tag.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,7 +44,10 @@ libevent/build: libevent/Makefile
 	cd libevent && $(MAKE) install
 
 tmux-src:
-	git clone $(TMUX_GIT_REPOSITORY_URL) $@
+	git clone $(TMUX_GIT_REPOSITORY_URL) $@; \
+	cd $@; \
+	git fetch origin --tags; \
+	git checkout 1.9a; \
 
 update: tmux-src
 	@set -e; \


### PR DESCRIPTION
When building, I found I had issues applying the patches. Realised this was because the master of tmux goes beyond tmux-1.9a, so to fix, checkout that tag specifically.
